### PR TITLE
sample-app-taprio: adapt definitons to content of uapi/linux/net_tstamp.h

### DIFF
--- a/sample-app-taprio/sample-app-taprio.c
+++ b/sample-app-taprio/sample-app-taprio.c
@@ -227,20 +227,23 @@ typedef struct {
 	uint16_t udp_dest;
 } socket_fd_ptrs;
 
-/*
- * The API for SO_TXTIME is the below struct and enum, which will be
- * provided by uapi/linux/net_tstamp.h in the near future.
- */
-struct sock_txtime {
-	clockid_t clockid;
-	uint16_t flags;
-};
-
 typedef struct {
 	uint64_t offset;
 	uint64_t duration;
 	uint8_t num_packets;
 } tx_window;
+
+
+#if __GNUC__ < 9
+/*
+ * The API for SO_TXTIME is the below struct and enum, which is
+ * provided by uapi/linux/net_tstamp.h in modern systems.
+ */
+
+struct sock_txtime {
+	clockid_t clockid;
+	uint16_t flags;
+};
 
 enum txtime_flags {
 	SOF_TXTIME_DEADLINE_MODE = (1 << 0),
@@ -250,6 +253,7 @@ enum txtime_flags {
 	SOF_TXTIME_FLAGS_MASK = (SOF_TXTIME_FLAGS_LAST - 1) |
 				 SOF_TXTIME_FLAGS_LAST
 };
+#endif
 
 /********** globals *************/
 


### PR DESCRIPTION
sample-app-taprio: adapt definitons to content of uapi/linux/net_tstamp.h

compiles under Ubuntu 18.04 and 20.04 (gcc 9.x)